### PR TITLE
Fix pnpm lint failing to load TypeScript config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Lint
+        run: pnpm run lint
+
       - name: Unit tests
         run: pnpm run test:unit

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-options="--experimental-strip-types"

--- a/src/utils/__tests__/time.spec.ts
+++ b/src/utils/__tests__/time.spec.ts
@@ -5,7 +5,7 @@ describe('pause', () => {
   it('resolves after the specified duration', async () => {
     vi.useFakeTimers();
     let resolved = false;
-    pause(1000).then(() => {
+    void pause(1000).then(() => {
       resolved = true;
     });
 


### PR DESCRIPTION
## Summary
- Add `.npmrc` with `node-options="--experimental-strip-types"` so Node 22 can load `vite.config.ts` when pnpm spawns the `vp` binary (fixes `ERR_UNKNOWN_FILE_EXTENSION` error)
- Suppress `no-floating-promises` lint warning in `time.spec.ts` with `void` operator

## Test plan
- [x] `pnpm lint` exits 0 with no warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)