### PR TITLE
fix: stop lust allocation from starving completable teams

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -13,7 +13,7 @@ body {
 
 .spec_death-knight_blood,
 .spec_death-knight_frost {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -28,7 +28,7 @@ body {
 
 .spec_death-knight_unholy,
 .spec_demon-hunter_devourer {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -43,7 +43,7 @@ body {
 
 .spec_demon-hunter_havoc,
 .spec_demon-hunter_vengeance {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -58,7 +58,7 @@ body {
 
 .spec_druid_balance,
 .spec_druid_feral {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -73,7 +73,7 @@ body {
 
 .spec_druid_guardian,
 .spec_druid_restoration {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -88,7 +88,7 @@ body {
 
 .spec_evoker_augmentation,
 .spec_evoker_devastation {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -103,7 +103,7 @@ body {
 
 .spec_evoker_preservation,
 .spec_hunter_beast-mastery {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -118,7 +118,7 @@ body {
 
 .spec_hunter_marksmanship,
 .spec_hunter_survival {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -133,7 +133,7 @@ body {
 
 .spec_mage_arcane,
 .spec_mage_fire {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -148,7 +148,7 @@ body {
 
 .spec_mage_frost,
 .spec_monk_brewmaster {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -163,7 +163,7 @@ body {
 
 .spec_monk_mistweaver,
 .spec_monk_windwalker {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -178,7 +178,7 @@ body {
 
 .spec_paladin_holy,
 .spec_paladin_protection {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -193,7 +193,7 @@ body {
 
 .spec_paladin_retribution,
 .spec_priest_discipline {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -208,7 +208,7 @@ body {
 
 .spec_priest_holy,
 .spec_priest_shadow {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -223,7 +223,7 @@ body {
 
 .spec_rogue_assassination,
 .spec_rogue_combat {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -238,7 +238,7 @@ body {
 
 .spec_rogue_outlaw,
 .spec_rogue_subtlety {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -253,7 +253,7 @@ body {
 
 .spec_shaman_elemental,
 .spec_shaman_enhancement {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -268,7 +268,7 @@ body {
 
 .spec_shaman_restoration,
 .spec_warlock_affliction {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -283,7 +283,7 @@ body {
 
 .spec_warlock_demonology,
 .spec_warlock_destruction {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -298,7 +298,7 @@ body {
 
 .spec_warrior_arms,
 .spec_warrior_fury {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   height: 64px;
   width: 64px;
 }
@@ -308,7 +308,7 @@ body {
 }
 
 .spec_warrior_protection {
-  background-image: url("../images/specs.png");
+  background-image: url('../images/specs.png');
   background-position: -384px -256px;
   height: 64px;
   width: 64px;
@@ -323,7 +323,7 @@ body {
 
 .class_death-knight,
 .class_demon-hunter {
-  background-image: url("../images/classes.png");
+  background-image: url('../images/classes.png');
   height: 64px;
   width: 64px;
 }
@@ -338,7 +338,7 @@ body {
 
 .class_druid,
 .class_evoker {
-  background-image: url("../images/classes.png");
+  background-image: url('../images/classes.png');
   height: 64px;
   width: 64px;
 }
@@ -353,7 +353,7 @@ body {
 
 .class_hunter,
 .class_mage {
-  background-image: url("../images/classes.png");
+  background-image: url('../images/classes.png');
   height: 64px;
   width: 64px;
 }
@@ -368,7 +368,7 @@ body {
 
 .class_monk,
 .class_paladin {
-  background-image: url("../images/classes.png");
+  background-image: url('../images/classes.png');
   height: 64px;
   width: 64px;
 }
@@ -383,7 +383,7 @@ body {
 
 .class_priest,
 .class_rogue {
-  background-image: url("../images/classes.png");
+  background-image: url('../images/classes.png');
   height: 64px;
   width: 64px;
 }
@@ -398,7 +398,7 @@ body {
 
 .class_shaman,
 .class_warlock {
-  background-image: url("../images/classes.png");
+  background-image: url('../images/classes.png');
   height: 64px;
   width: 64px;
 }
@@ -408,7 +408,7 @@ body {
 }
 
 .class_warrior {
-  background-image: url("../images/classes.png");
+  background-image: url('../images/classes.png');
   background-position: 0 -192px;
   height: 64px;
   width: 64px;

--- a/src/data/specs.ts
+++ b/src/data/specs.ts
@@ -1,96 +1,93 @@
-import type { ClassType, ClassSpec, ClassRole } from "../types";
+import type { ClassType, ClassSpec, ClassRole } from '../types';
 
 export const classSpecs: Record<ClassType, ClassSpec[]> = {
-  Priest: ["Holy", "Discipline", "Shadow"],
-  Warrior: ["Arms", "Fury", "Protection"],
-  Mage: ["Fire", "Frost", "Arcane"],
-  Rogue: ["Subtlety", "Outlaw", "Assassination"],
-  Hunter: ["Beast Mastery", "Marksmanship", "Survival"],
-  Warlock: ["Affliction", "Demonology", "Destruction"],
-  Shaman: ["Elemental", "Enhancement", "Restoration"],
-  Druid: ["Restoration", "Balance", "Feral", "Guardian"],
-  Paladin: ["Protection", "Retribution", "Holy"],
-  "Demon Hunter": ["Vengeance", "Havoc", "Devourer"],
-  "Death Knight": ["Blood", "Unholy", "Frost"],
-  Monk: ["Windwalker", "Brewmaster", "Mistweaver"],
-  Evoker: ["Devastation", "Preservation", "Augmentation"],
+  Priest: ['Holy', 'Discipline', 'Shadow'],
+  Warrior: ['Arms', 'Fury', 'Protection'],
+  Mage: ['Fire', 'Frost', 'Arcane'],
+  Rogue: ['Subtlety', 'Outlaw', 'Assassination'],
+  Hunter: ['Beast Mastery', 'Marksmanship', 'Survival'],
+  Warlock: ['Affliction', 'Demonology', 'Destruction'],
+  Shaman: ['Elemental', 'Enhancement', 'Restoration'],
+  Druid: ['Restoration', 'Balance', 'Feral', 'Guardian'],
+  Paladin: ['Protection', 'Retribution', 'Holy'],
+  'Demon Hunter': ['Vengeance', 'Havoc', 'Devourer'],
+  'Death Knight': ['Blood', 'Unholy', 'Frost'],
+  Monk: ['Windwalker', 'Brewmaster', 'Mistweaver'],
+  Evoker: ['Devastation', 'Preservation', 'Augmentation']
 };
 
-export const classSpecRole: Record<
-  ClassType,
-  Partial<Record<ClassSpec, ClassRole>>
-> = {
+export const classSpecRole: Record<ClassType, Partial<Record<ClassSpec, ClassRole>>> = {
   Priest: {
-    Holy: "HEALING",
-    Discipline: "HEALING",
-    Shadow: "DPS",
+    Holy: 'HEALING',
+    Discipline: 'HEALING',
+    Shadow: 'DPS'
   },
   Warrior: {
-    Arms: "DPS",
-    Fury: "DPS",
-    Protection: "TANK",
+    Arms: 'DPS',
+    Fury: 'DPS',
+    Protection: 'TANK'
   },
   Mage: {
-    Fire: "DPS",
-    Frost: "DPS",
-    Arcane: "DPS",
+    Fire: 'DPS',
+    Frost: 'DPS',
+    Arcane: 'DPS'
   },
   Rogue: {
-    Subtlety: "DPS",
-    Outlaw: "DPS",
-    Assassination: "DPS",
+    Subtlety: 'DPS',
+    Outlaw: 'DPS',
+    Assassination: 'DPS'
   },
   Hunter: {
-    "Beast Mastery": "DPS",
-    Marksmanship: "DPS",
-    Survival: "DPS",
+    'Beast Mastery': 'DPS',
+    Marksmanship: 'DPS',
+    Survival: 'DPS'
   },
   Warlock: {
-    Affliction: "DPS",
-    Demonology: "DPS",
-    Destruction: "DPS",
+    Affliction: 'DPS',
+    Demonology: 'DPS',
+    Destruction: 'DPS'
   },
   Shaman: {
-    Elemental: "DPS",
-    Enhancement: "DPS",
-    Restoration: "HEALING",
+    Elemental: 'DPS',
+    Enhancement: 'DPS',
+    Restoration: 'HEALING'
   },
   Druid: {
-    Restoration: "HEALING",
-    Balance: "DPS",
-    Feral: "DPS",
-    Guardian: "TANK",
+    Restoration: 'HEALING',
+    Balance: 'DPS',
+    Feral: 'DPS',
+    Guardian: 'TANK'
   },
   Paladin: {
-    Protection: "TANK",
-    Retribution: "DPS",
-    Holy: "HEALING",
+    Protection: 'TANK',
+    Retribution: 'DPS',
+    Holy: 'HEALING'
   },
-  "Demon Hunter": {
-    Vengeance: "TANK",
-    Havoc: "DPS",
-    Devourer: "DPS",
+  'Demon Hunter': {
+    Vengeance: 'TANK',
+    Havoc: 'DPS',
+    Devourer: 'DPS'
   },
-  "Death Knight": {
-    Blood: "TANK",
-    Unholy: "DPS",
-    Frost: "DPS",
+  'Death Knight': {
+    Blood: 'TANK',
+    Unholy: 'DPS',
+    Frost: 'DPS'
   },
   Monk: {
-    Windwalker: "DPS",
-    Brewmaster: "TANK",
-    Mistweaver: "HEALING",
+    Windwalker: 'DPS',
+    Brewmaster: 'TANK',
+    Mistweaver: 'HEALING'
   },
   Evoker: {
-    Devastation: "DPS",
-    Preservation: "HEALING",
-    Augmentation: "DPS",
-  },
+    Devastation: 'DPS',
+    Preservation: 'HEALING',
+    Augmentation: 'DPS'
+  }
 };
 
 export const classSpecLust: Partial<Record<ClassType, boolean>> = {
   Mage: true,
   Hunter: true,
   Shaman: true,
-  Evoker: true,
+  Evoker: true
 };

--- a/src/stores/__tests__/members.store.spec.ts
+++ b/src/stores/__tests__/members.store.spec.ts
@@ -5,7 +5,7 @@ import { useMembersStore } from '../members.store';
 import { useConfigStore } from '../config.store';
 import { useTeamsStore } from '../teams.store';
 import { nextTick, ref, type Ref } from 'vue';
-import type { GuildProfile, Member } from '../../types';
+import type { GuildProfile, Member, ClassRole } from '../../types';
 import { mockGuildProfile } from '../../data/__mocks__/mock-guild-profile';
 import { useAlertStore } from '../alert.store';
 import { mockMembers } from '../../data/__mocks__/mock-members';
@@ -593,133 +593,255 @@ describe('members store', () => {
     expect(teams.teams.length).toBe(2);
     for (const team of teams.teams) {
       expect(team.members.length).toBe(5);
-      expect(
-        team.members.filter((m) => m.character.active_spec_role === 'TANK').length
-      ).toBe(1);
-      expect(
-        team.members.filter((m) => m.character.active_spec_role === 'HEALING').length
-      ).toBe(1);
-      expect(
-        team.members.filter((m) => m.character.active_spec_role === 'DPS').length
-      ).toBe(3);
+      expect(team.members.filter((m) => m.character.active_spec_role === 'TANK').length).toBe(1);
+      expect(team.members.filter((m) => m.character.active_spec_role === 'HEALING').length).toBe(1);
+      expect(team.members.filter((m) => m.character.active_spec_role === 'DPS').length).toBe(3);
     }
   });
 
-  test('it handles multi-spec lust players without depleting healer pool', { repeats: 25 }, async () => {
-    const store = useMembersStore();
-    const config = useConfigStore();
-    const teams = useTeamsStore();
+  test(
+    'it handles multi-spec lust players without depleting healer pool',
+    { repeats: 25 },
+    async () => {
+      const store = useMembersStore();
+      const config = useConfigStore();
+      const teams = useTeamsStore();
 
-    config.spreadLust = true;
-    config.autoPug = false;
-    config.fancy = false;
+      config.spreadLust = true;
+      config.autoPug = false;
+      config.fancy = false;
 
-    // Shaman selected with both Resto (HEALING) and Enhance (DPS) specs
-    // If the DPS entry is used as lust, pruneWorkingMembers removes the healer entry too,
-    // depleting the healer pool and leaving another team without a healer
-    const members: Member[] = [
-      {
-        character: {
-          name: 'FlexShaman',
-          class: 'Shaman',
-          active_spec_name: 'Restoration',
-          active_spec_role: 'HEALING',
-          realm: 'Test'
+      // Shaman selected with both Resto (HEALING) and Enhance (DPS) specs
+      // If the DPS entry is used as lust, pruneWorkingMembers removes the healer entry too,
+      // depleting the healer pool and leaving another team without a healer
+      const members: Member[] = [
+        {
+          character: {
+            name: 'FlexShaman',
+            class: 'Shaman',
+            active_spec_name: 'Restoration',
+            active_spec_role: 'HEALING',
+            realm: 'Test'
+          },
+          rank: 1
         },
-        rank: 1
-      },
-      {
-        character: {
-          name: 'FlexShaman',
-          class: 'Shaman',
-          active_spec_name: 'Enhancement',
-          active_spec_role: 'DPS',
-          realm: 'Test'
+        {
+          character: {
+            name: 'FlexShaman',
+            class: 'Shaman',
+            active_spec_name: 'Enhancement',
+            active_spec_role: 'DPS',
+            realm: 'Test'
+          },
+          rank: 1
         },
-        rank: 1
-      },
-      {
-        character: {
-          name: 'Healer2',
-          class: 'Paladin',
-          active_spec_name: 'Holy',
-          active_spec_role: 'HEALING',
-          realm: 'Test'
+        {
+          character: {
+            name: 'Healer2',
+            class: 'Paladin',
+            active_spec_name: 'Holy',
+            active_spec_role: 'HEALING',
+            realm: 'Test'
+          },
+          rank: 1
         },
-        rank: 1
-      },
-      {
-        character: {
-          name: 'Tank1',
-          class: 'Warrior',
-          active_spec_name: 'Protection',
-          active_spec_role: 'TANK',
-          realm: 'Test'
+        {
+          character: {
+            name: 'Tank1',
+            class: 'Warrior',
+            active_spec_name: 'Protection',
+            active_spec_role: 'TANK',
+            realm: 'Test'
+          },
+          rank: 1
         },
-        rank: 1
-      },
-      {
-        character: {
-          name: 'Tank2',
-          class: 'Death Knight',
-          active_spec_name: 'Blood',
-          active_spec_role: 'TANK',
-          realm: 'Test'
+        {
+          character: {
+            name: 'Tank2',
+            class: 'Death Knight',
+            active_spec_name: 'Blood',
+            active_spec_role: 'TANK',
+            realm: 'Test'
+          },
+          rank: 1
         },
-        rank: 1
-      },
-      {
-        character: {
-          name: 'LustDPS',
-          class: 'Mage',
-          active_spec_name: 'Fire',
-          active_spec_role: 'DPS',
-          realm: 'Test'
+        {
+          character: {
+            name: 'LustDPS',
+            class: 'Mage',
+            active_spec_name: 'Fire',
+            active_spec_role: 'DPS',
+            realm: 'Test'
+          },
+          rank: 1
         },
-        rank: 1
-      },
-      ...Array.from({ length: 5 }, (_, i) => ({
-        character: {
-          name: `DPS${i + 1}`,
-          class: 'Rogue' as const,
-          active_spec_name: 'Outlaw' as const,
-          active_spec_role: 'DPS' as const,
-          realm: 'Test'
-        },
-        rank: 1
-      }))
-    ];
+        ...Array.from({ length: 5 }, (_, i) => ({
+          character: {
+            name: `DPS${i + 1}`,
+            class: 'Rogue' as const,
+            active_spec_name: 'Outlaw' as const,
+            active_spec_role: 'DPS' as const,
+            realm: 'Test'
+          },
+          rank: 1
+        }))
+      ];
 
-    store.selectedMembers = members;
+      store.selectedMembers = members;
 
-    await store.randomise();
+      await store.randomise();
 
-    // 10 unique players = 2 teams (FlexShaman counted once)
-    expect(teams.teams.length).toBe(2);
+      // 10 unique players = 2 teams (FlexShaman counted once)
+      expect(teams.teams.length).toBe(2);
+      for (const team of teams.teams) {
+        expect(team.members.length).toBe(5);
+        expect(team.members.filter((m) => m.character.active_spec_role === 'TANK').length).toBe(1);
+        expect(team.members.filter((m) => m.character.active_spec_role === 'HEALING').length).toBe(
+          1
+        );
+        expect(team.members.filter((m) => m.character.active_spec_role === 'DPS').length).toBe(3);
+
+        // No duplicate players within a team
+        const unique = new Set(team.members.map((m) => `${m.character.name}-${m.character.realm}`));
+        expect(unique.size).toBe(5);
+      }
+
+      // No duplicate players across teams
+      const allPlayers = teams.teams.flatMap((t) =>
+        t.members.map((m) => `${m.character.name}-${m.character.realm}`)
+      );
+      const allUnique = new Set(allPlayers);
+      expect(allUnique.size).toBe(allPlayers.length);
+    }
+  );
+
+  // Regression: when ceil(players / 5) produces more team slots than can be
+  // completed, the trailing (un-completable) slot used to consume a scarce
+  // lust-capable healer, starving a completable team so it was silently dropped.
+  let regId = 0;
+  const mkMember = (
+    cls: Member['character']['class'],
+    spec: Member['character']['active_spec_name'],
+    role: ClassRole
+  ): Member => ({
+    rank: 1,
+    character: {
+      name: `Reg${regId++}`,
+      class: cls,
+      active_spec_name: spec,
+      active_spec_role: role,
+      realm: 'Test'
+    }
+  });
+
+  const assertCompleteTeams = (teams: ReturnType<typeof useTeamsStore>, count: number) => {
+    expect(teams.teams.length).toBe(count);
     for (const team of teams.teams) {
       expect(team.members.length).toBe(5);
-      expect(
-        team.members.filter((m) => m.character.active_spec_role === 'TANK').length
-      ).toBe(1);
-      expect(
-        team.members.filter((m) => m.character.active_spec_role === 'HEALING').length
-      ).toBe(1);
-      expect(
-        team.members.filter((m) => m.character.active_spec_role === 'DPS').length
-      ).toBe(3);
-
-      // No duplicate players within a team
-      const unique = new Set(
-        team.members.map((m) => `${m.character.name}-${m.character.realm}`)
-      );
-      expect(unique.size).toBe(5);
+      expect(team.members.filter((m) => m.character.active_spec_role === 'TANK').length).toBe(1);
+      expect(team.members.filter((m) => m.character.active_spec_role === 'HEALING').length).toBe(1);
+      expect(team.members.filter((m) => m.character.active_spec_role === 'DPS').length).toBe(3);
     }
+  };
 
-    // No duplicate players across teams
-    const allPlayers = teams.teams.flatMap((t) =>
-      t.members.map((m) => `${m.character.name}-${m.character.realm}`)
-    );
-    const allUnique = new Set(allPlayers);
-    expect(allUnique.size).toBe(allPlayers.length);
-  });
+  test(
+    'it forms two complete teams from 2 tanks, 2 healers and surplus dps with lust spread',
+    { repeats: 25, timeout: 30000 },
+    async () => {
+      const store = useMembersStore();
+      const config = useConfigStore();
+      const teams = useTeamsStore();
+      config.spreadLust = true;
+      config.autoPug = false;
+      config.fancy = false;
+
+      // 2 tanks, 2 lust-capable healers, 10 dps (mostly lust) => 14 players.
+      // ceil(14 / 5) === 3 slots but only 2 teams are completable.
+      store.selectedMembers = [
+        mkMember('Warrior', 'Protection', 'TANK'),
+        mkMember('Death Knight', 'Blood', 'TANK'),
+        mkMember('Shaman', 'Restoration', 'HEALING'),
+        mkMember('Evoker', 'Preservation', 'HEALING'),
+        mkMember('Mage', 'Fire', 'DPS'),
+        mkMember('Hunter', 'Marksmanship', 'DPS'),
+        mkMember('Shaman', 'Elemental', 'DPS'),
+        mkMember('Evoker', 'Devastation', 'DPS'),
+        mkMember('Mage', 'Frost', 'DPS'),
+        mkMember('Hunter', 'Beast Mastery', 'DPS'),
+        mkMember('Rogue', 'Outlaw', 'DPS'),
+        mkMember('Warrior', 'Arms', 'DPS'),
+        mkMember('Rogue', 'Assassination', 'DPS'),
+        mkMember('Mage', 'Arcane', 'DPS')
+      ];
+
+      await store.randomise();
+      assertCompleteTeams(teams, 2);
+    }
+  );
+
+  test(
+    'it does not let an un-completable slot starve a team when dps is scarce',
+    { repeats: 25, timeout: 30000 },
+    async () => {
+      const store = useMembersStore();
+      const config = useConfigStore();
+      const teams = useTeamsStore();
+      config.spreadLust = true;
+      config.autoPug = false;
+      config.fancy = false;
+
+      // 3 tanks, 3 healers, only 6 dps => 12 players, ceil = 3 slots but dps only
+      // supports 2 complete teams.
+      store.selectedMembers = [
+        mkMember('Warrior', 'Protection', 'TANK'),
+        mkMember('Death Knight', 'Blood', 'TANK'),
+        mkMember('Monk', 'Brewmaster', 'TANK'),
+        mkMember('Shaman', 'Restoration', 'HEALING'),
+        mkMember('Evoker', 'Preservation', 'HEALING'),
+        mkMember('Priest', 'Holy', 'HEALING'),
+        mkMember('Mage', 'Fire', 'DPS'),
+        mkMember('Hunter', 'Marksmanship', 'DPS'),
+        mkMember('Rogue', 'Outlaw', 'DPS'),
+        mkMember('Warrior', 'Arms', 'DPS'),
+        mkMember('Shaman', 'Elemental', 'DPS'),
+        mkMember('Evoker', 'Devastation', 'DPS')
+      ];
+
+      await store.randomise();
+      assertCompleteTeams(teams, 2);
+    }
+  );
+
+  test(
+    'stale captain flags do not drop a completable team',
+    { repeats: 25, timeout: 30000 },
+    async () => {
+      const store = useMembersStore();
+      const config = useConfigStore();
+      const teams = useTeamsStore();
+      config.spreadLust = true;
+      config.autoPug = false;
+      config.fancy = false;
+
+      const members = [
+        mkMember('Warrior', 'Protection', 'TANK'),
+        mkMember('Death Knight', 'Blood', 'TANK'),
+        mkMember('Shaman', 'Restoration', 'HEALING'),
+        mkMember('Evoker', 'Preservation', 'HEALING'),
+        mkMember('Mage', 'Fire', 'DPS'),
+        mkMember('Hunter', 'Marksmanship', 'DPS'),
+        mkMember('Shaman', 'Elemental', 'DPS'),
+        mkMember('Evoker', 'Devastation', 'DPS'),
+        mkMember('Mage', 'Frost', 'DPS'),
+        mkMember('Rogue', 'Outlaw', 'DPS')
+      ];
+      // a previous randomisation left stale captain flags behind
+      members[2].captain = true;
+      members[4].captain = true;
+      store.selectedMembers = members;
+
+      await store.randomise();
+      assertCompleteTeams(teams, 2);
+    }
+  );
 });

--- a/src/stores/members.store.ts
+++ b/src/stores/members.store.ts
@@ -367,56 +367,34 @@ export const useMembersStore = defineStore('members', () => {
     const isHealer = (member: Member) => member.character.active_spec_role === 'HEALING';
     const isDamageDealer = (member: Member) => member.character.active_spec_role === 'DPS';
 
-    // lust allocation logic - deduplicate by player, preferring healer entries
-    // Using a healer entry as lust fills both the lust and healer slot,
-    // preventing healer pool depletion when multi-spec players are selected
-    const lustProviderMap = new Map<string, Member>();
-    for (const member of workingMembers) {
-      if (member.captain || !classSpecLust[member.character.class]) continue;
-      const key = `${member.character.name}-${member.character.realm}`;
-      const existing = lustProviderMap.get(key);
-      if (!existing || (isHealer(member) && !isHealer(existing))) {
-        lustProviderMap.set(key, member);
-      }
-    }
-    const availableLustProviders = [...lustProviderMap.values()];
-    shuffle(availableLustProviders);
+    const hasLust = (team: Team) => team.members.some((m) => classSpecLust[m.character.class]);
 
+    // assign captains - one per team
     for (const team of workingTeams) {
-      // assign captains
       const captain = captains.shift();
       if (captain) {
         pruneWorkingMembers(captain);
         team.members.push(captain);
       }
-
-      // assign lusts
-      if (spreadLust.value) {
-        const captainHasLust = team.members.some((m) => classSpecLust[m.character.class]);
-        if (!captainHasLust) {
-          // pick a lust provider
-          // Try to find one that doesn't conflict with captain's role (specifically Healer/Tank)
-          const providerIndex = availableLustProviders.findIndex((m) => {
-            // If team has Healer, avoid Healer Lust
-            if (team.members.find(isHealer) && isHealer(m)) return false;
-            // If team has Tank, avoid Tank Lust (though none exist currently)
-            if (team.members.find(isTank) && isTank(m)) return false;
-            return true;
-          });
-
-          if (providerIndex !== -1) {
-            const lust = availableLustProviders[providerIndex];
-            pruneWorkingMembers(lust);
-            team.members.push(lust);
-            availableLustProviders.splice(providerIndex, 1);
-          }
-        }
-      }
     }
+
+    // Roles are assigned one whole pass at a time (every team gets a tank before
+    // any team gets a healer, etc.). This reserves the scarce tank/healer roles
+    // across all teams before damage dealers are handed out, which matters when
+    // players can fill multiple roles - otherwise a flex player could be spent as
+    // a dps on an early team and leave a later team with no tank/healer.
+    //
+    // Lust used to be a separate pass that ran *before* roles were assigned. When
+    // there were more team slots than completable teams (e.g. 2 tanks / 2 healers
+    // but ceil(players / 5) === 3 slots), that pre-pass let a doomed trailing slot
+    // grab a scarce lust-capable healer, starving an otherwise-completable team so
+    // it was silently dropped. Lust is now folded into the role passes as a
+    // preference - only ever picked to fill a slot the team needs anyway (its
+    // healer or a dps) - so spreading lust can no longer consume a scarce role a
+    // sibling team requires.
 
     // assign tanks
     for (const team of workingTeams) {
-      // skip if team captain was a tank
       if (team.members.find(isTank)) continue;
       const tank = workingMembers.find(isTank);
       if (tank) {
@@ -425,26 +403,33 @@ export const useMembersStore = defineStore('members', () => {
       }
     }
 
-    // assign healers
+    // assign healers, preferring a lust-capable healer when the team has no lust
+    // yet (a lust healer satisfies both needs without taking a dps slot)
     for (const team of workingTeams) {
-      // skip if team captain / lust was a healer
       if (team.members.find(isHealer)) continue;
-      const healer = workingMembers.find(isHealer);
+      let healer: Member | undefined;
+      if (spreadLust.value && !hasLust(team)) {
+        healer = workingMembers.find((m) => isHealer(m) && classSpecLust[m.character.class]);
+      }
+      if (!healer) healer = workingMembers.find(isHealer);
       if (healer) {
         pruneWorkingMembers(healer);
         team.members.push(healer);
       }
     }
 
-    // assign damage dealers
+    // assign damage dealers, filling each team to three before moving on and
+    // preferring a lust-capable dps while the team still has no lust provider
     for (const team of workingTeams) {
-      for (let i = 0; i < 3; i++) {
-        if (team.members.filter(isDamageDealer).length === 3) continue;
-        const dps = workingMembers.find(isDamageDealer);
-        if (dps) {
-          pruneWorkingMembers(dps);
-          team.members.push(dps);
+      while (team.members.filter(isDamageDealer).length < 3) {
+        let dps: Member | undefined;
+        if (spreadLust.value && !hasLust(team)) {
+          dps = workingMembers.find((m) => isDamageDealer(m) && classSpecLust[m.character.class]);
         }
+        if (!dps) dps = workingMembers.find(isDamageDealer);
+        if (!dps) break;
+        pruneWorkingMembers(dps);
+        team.members.push(dps);
       }
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,31 +1,31 @@
 export type ClassType =
-  | "Priest"
-  | "Warrior"
-  | "Mage"
-  | "Rogue"
-  | "Hunter"
-  | "Warlock"
-  | "Shaman"
-  | "Druid"
-  | "Paladin"
-  | "Demon Hunter"
-  | "Death Knight"
-  | "Monk"
-  | "Evoker";
+  | 'Priest'
+  | 'Warrior'
+  | 'Mage'
+  | 'Rogue'
+  | 'Hunter'
+  | 'Warlock'
+  | 'Shaman'
+  | 'Druid'
+  | 'Paladin'
+  | 'Demon Hunter'
+  | 'Death Knight'
+  | 'Monk'
+  | 'Evoker';
 
-export type PriestClassSpec = "Holy" | "Discipline" | "Shadow";
-export type WarriorClassSpec = "Arms" | "Fury" | "Protection";
-export type MageClassSpec = "Fire" | "Frost" | "Arcane";
-export type RogueClassSpec = "Subtlety" | "Outlaw" | "Assassination";
-export type HunterClassSpec = "Beast Mastery" | "Marksmanship" | "Survival";
-export type WarlockClassSpec = "Affliction" | "Demonology" | "Destruction";
-export type ShamanClassSpec = "Elemental" | "Enhancement" | "Restoration";
-export type DruidClassSpec = "Restoration" | "Balance" | "Feral" | "Guardian";
-export type PaladinClassSpec = "Protection" | "Retribution" | "Holy";
-export type DemonHunterClassSpec = "Vengeance" | "Havoc" | "Devourer";
-export type DeathKnightClassSpec = "Blood" | "Unholy" | "Frost";
-export type MonkClassSpec = "Windwalker" | "Brewmaster" | "Mistweaver";
-export type EvokerClassSpec = "Devastation" | "Preservation" | "Augmentation";
+export type PriestClassSpec = 'Holy' | 'Discipline' | 'Shadow';
+export type WarriorClassSpec = 'Arms' | 'Fury' | 'Protection';
+export type MageClassSpec = 'Fire' | 'Frost' | 'Arcane';
+export type RogueClassSpec = 'Subtlety' | 'Outlaw' | 'Assassination';
+export type HunterClassSpec = 'Beast Mastery' | 'Marksmanship' | 'Survival';
+export type WarlockClassSpec = 'Affliction' | 'Demonology' | 'Destruction';
+export type ShamanClassSpec = 'Elemental' | 'Enhancement' | 'Restoration';
+export type DruidClassSpec = 'Restoration' | 'Balance' | 'Feral' | 'Guardian';
+export type PaladinClassSpec = 'Protection' | 'Retribution' | 'Holy';
+export type DemonHunterClassSpec = 'Vengeance' | 'Havoc' | 'Devourer';
+export type DeathKnightClassSpec = 'Blood' | 'Unholy' | 'Frost';
+export type MonkClassSpec = 'Windwalker' | 'Brewmaster' | 'Mistweaver';
+export type EvokerClassSpec = 'Devastation' | 'Preservation' | 'Augmentation';
 
 export type ClassSpec =
   | PriestClassSpec
@@ -42,8 +42,8 @@ export type ClassSpec =
   | MonkClassSpec
   | EvokerClassSpec;
 
-export type ClassRole = "DPS" | "TANK" | "HEALING";
-export type ClassFilter = ClassRole | "ALL";
+export type ClassRole = 'DPS' | 'TANK' | 'HEALING';
+export type ClassFilter = ClassRole | 'ALL';
 
 export interface Character {
   name: string;
@@ -51,8 +51,8 @@ export interface Character {
   class: ClassType;
   active_spec_name: ClassSpec;
   active_spec_role: ClassRole;
-  gender?: "male" | "female";
-  faction?: "horde" | "alliance";
+  gender?: 'male' | 'female';
+  faction?: 'horde' | 'alliance';
   achievement_points?: number;
   honorable_kills?: number;
   region?: Lowercase<Region>;
@@ -88,11 +88,11 @@ export interface Member {
 }
 
 export interface IAlert {
-  type: "error" | "warning" | "success";
+  type: 'error' | 'warning' | 'success';
   message: string;
 }
 
-export type Region = "CN" | "EU" | "KR" | "TW" | "US";
+export type Region = 'CN' | 'EU' | 'KR' | 'TW' | 'US';
 
 export interface IRegion {
   value: Region;


### PR DESCRIPTION
## Problem

A re-occurrence of the "fewer groups than it should" bug: with **2 tanks, 2 healers and 6+ dps** (enough for 2 complete teams) and lots of lust classes, the randomiser produced only **one** team.

## Root cause

`amount = ceil(players / 5)` can be larger than the number of teams that can actually be completed. With 2 tanks / 2 healers / 10 dps that's `ceil(14/5) = 3` slots but only **2** completable teams.

The lust allocation ran as a separate pass **before** roles were assigned, iterating every slot — including the doomed 3rd one. That doomed slot was allowed to grab a scarce **lust-capable healer**, consuming one of only two healers. A genuinely completable team was then left with 4 members and silently dropped (teams are only kept when `members.length === 5`).

[#12](https://github.com/devi4nt/mythic-plus-team-randomiser/pull/12) (74024d0) fixed lust *over-stacking* a team to 6; it didn't cover this *starvation* case. This was reproduced deterministically with **no captains at all**, so stale captain flags are not the cause.

## Fix

Fold lust into the role-assignment passes as a *preference* rather than a separate pre-pass:

- Assign **tanks → healers → dps** in full round-robin passes, so the scarce tank/healer roles are reserved across every team before dps are handed out. (This ordering is what keeps multi-spec / flex players working — they aren't spent as dps on an early team and missed as a tank/healer on a later one.)
- Prefer a lust-capable member only when filling a slot the team needs anyway (its healer, or a dps), so spreading lust can never consume a scarce role a sibling team requires.
- Remove the now-redundant lust-provider de-dup map — pruning by player already prevents multi-spec players being picked twice.

## Tests

Added regression tests for three shapes that previously dropped a team:
- 2 tanks / 2 healers / surplus dps (the reported case)
- 3 tanks / 3 healers / scarce dps (doomed slot stealing dps)
- the reported case with stale captain flags set

All 35 tests pass; lint, typecheck and formatting are clean. (The diff also includes formatter output across the touched files, which were not previously formatted to the current config.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)